### PR TITLE
fix-world-names

### DIFF
--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -222,6 +222,8 @@ public class Level implements ChunkManager, Metadatable {
             throw new LevelException("Caused by " + Utils.getExceptionMessage(e));
         }
 
+        this.provider.updateLevelName(name);
+
         this.server.getLogger().info(this.server.getLanguage().translateString("nukkit.level.preparing",
                 TextFormat.GREEN + this.provider.getName() + TextFormat.WHITE));
 

--- a/src/main/java/cn/nukkit/level/format/LevelProvider.java
+++ b/src/main/java/cn/nukkit/level/format/LevelProvider.java
@@ -92,4 +92,6 @@ public interface LevelProvider {
     void close();
 
     void saveLevelData();
+
+    void updateLevelName(String name);
 }

--- a/src/main/java/cn/nukkit/level/format/generic/BaseLevelProvider.java
+++ b/src/main/java/cn/nukkit/level/format/generic/BaseLevelProvider.java
@@ -169,4 +169,9 @@ public abstract class BaseLevelProvider implements LevelProvider {
         }
     }
 
+    public void updateLevelName(String name){
+        if (!this.getName().equals(name)){
+            this.levelData.putString("LevelName",name);
+        }
+    }
 }

--- a/src/main/java/cn/nukkit/level/format/leveldb/LevelDB.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/LevelDB.java
@@ -497,4 +497,9 @@ public class LevelDB implements LevelProvider {
         return levelData;
     }
 
+    public void updateLevelName(String name){
+        if (!this.getName().equals(name)){
+            this.levelData.putString("LevelName",name);
+        }
+    }
 }


### PR DESCRIPTION
Update level name during level loading (to prevent situation when two (or more) level could have same names)